### PR TITLE
Change Stream Analytics job's blob storage output format to 'Array'

### DIFF
--- a/Data/Module1-IntelligentApp/README.md
+++ b/Data/Module1-IntelligentApp/README.md
@@ -235,7 +235,7 @@ In this task, you'll create an output that will store the query results in Blob 
 	- **Path pattern**: Type in a file prefix to use when writing blob output. E.g. analyticsoutput-{date}
 	- **Event Serializer Format**: JSON.
 	- **Encoding**: UTF8.
-	- **Format**: Line Separated
+	- **Format**: Array
 
 1. Click **Create**.
 


### PR DESCRIPTION
I would hardly recommend to store the data inside the blobs in the Array format. They are JSON objects and saving them line separated creates an invalid(!) JSON file. The correct JSON format would be comma separated and with square brackets around the full document. The 'Array' format does exactly that!